### PR TITLE
Normalize strings

### DIFF
--- a/src/CoVoX/API/Modules/Understanding/Interpreters/TokenSimilarityInterpreter.cs
+++ b/src/CoVoX/API/Modules/Understanding/Interpreters/TokenSimilarityInterpreter.cs
@@ -6,9 +6,6 @@ namespace Covox.Understanding
     {
         public double CalculateMatchScore(string target, string input)
         {
-            target = target.ToLowerInvariant();
-            input = input.ToLowerInvariant();
-
             var targetTokens = target.Split(' ').ToList();
             var inputTokens = targetTokens.Where(token => input.ToLower().Contains(token)).ToList();
 

--- a/src/CoVoX/API/Modules/Understanding/UnderstandingModule.cs
+++ b/src/CoVoX/API/Modules/Understanding/UnderstandingModule.cs
@@ -68,10 +68,12 @@ namespace Covox.Understanding
 
         private double CalculateHighestSimilarity(string input, Command command)
         {
+            input = NormalizeString(input);
+
             var highestPercentage = 0.0;
             foreach (var trigger in command.VoiceTriggers)
             {
-                var percentage = _interpreter.CalculateMatchScore(trigger, input);
+                var percentage = _interpreter.CalculateMatchScore(NormalizeString(trigger), input);
                 if (percentage > highestPercentage)
                 {
                     highestPercentage = percentage;
@@ -79,6 +81,11 @@ namespace Covox.Understanding
             }
 
             return highestPercentage;
+        }
+
+        private string NormalizeString(string input)
+        {
+            return new string(input.Where(c => !char.IsPunctuation(c)).ToArray()).ToLowerInvariant();
         }
     }
 }


### PR DESCRIPTION
Introduces the normalization of the input and target strings in the UnderstandingModule

```csharp
private string NormalizeString(string input)
{
   return new string(input.Where(c => !char.IsPunctuation(c)).ToArray()).ToLowerInvariant();
}
```

Resolves #55 .